### PR TITLE
feat(component): Simplify component usage by accepting full & thumbs together

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ import '@browniebroke/gatsby-image-gallery/dist/style.css'
 
 class Example extends Component {
   render() {
-    return <Gallery />
+    return <Gallery images={{images}/>
   }
 }
 ```
+
+For a full working example, there is one in [the example folder](https://github.com/browniebroke/gatsby-image-gallery/tree/master/example) which is [deployed to Netlify](https://gatsby-image-gallery.netlify.app/).
 
 ## Development
 

--- a/example/src/pages/index.js
+++ b/example/src/pages/index.js
@@ -6,14 +6,13 @@ import SEO from '../components/seo'
 import Gallery from '../../../gatsby-image-gallery/src'
 
 const IndexPage = ({ data }) => {
-  const fullSize = data.images.edges.map((edge) => edge.node.full.fluid.src)
-  const thumbs = data.images.edges.map((edge) => edge.node.thumb.fluid)
+  const images = data.images.edges
   return (
     <Layout>
       <SEO title="Example" />
       <h1>Gatsby image gallery demo</h1>
       <p>A very simple page to demo the gallery component.</p>
-      <Gallery images={fullSize} thumbs={thumbs} />
+      <Gallery images={images} />
     </Layout>
   )
 }
@@ -26,18 +25,11 @@ export const query = graphql`
     ) {
       edges {
         node {
-          id
-          thumb: childImageSharp {
-            fluid(maxWidth: 270, maxHeight: 270) {
+          childImageSharp {
+            thumb: fluid(maxWidth: 270, maxHeight: 270) {
               ...GatsbyImageSharpFluid
             }
-          }
-          full: childImageSharp {
-            fluid(
-              maxWidth: 1024
-              quality: 85
-              srcSetBreakpoints: [576, 768, 992, 1200]
-            ) {
+            fluid(maxWidth: 1024) {
               ...GatsbyImageSharpFluid
             }
           }

--- a/gatsby-image-gallery/package.json
+++ b/gatsby-image-gallery/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "cross-env CI=1 SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jsdom",
-    "test:watch": "react-scripts test --env=jsdom",
+    "test:watch": "SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jsdom",
     "build": "rollup -c",
     "start": "rollup -c -w",
     "prepare": "yarn run build"

--- a/gatsby-image-gallery/src/__snapshots__/index.test.js.snap
+++ b/gatsby-image-gallery/src/__snapshots__/index.test.js.snap
@@ -157,6 +157,163 @@ exports[`Gallery component that it renders with a custom column class 1`] = `
 </React.Fragment>
 `;
 
+exports[`Gallery component that it renders with data in fullImages & thumbs 1`] = `
+<React.Fragment>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "fluid": Object {
+                "aspectRatio": 1.5,
+                "base64": "string_of_base64",
+                "sizes": "(max-width: 600px) 100vw, 600px",
+                "src": "/thumb/image001.jpg",
+                "srcSet": "some srcSet",
+                "srcSetWebp": "some srcSetWebp",
+              },
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "fluid": Object {
+                "aspectRatio": 1.5,
+                "base64": "string_of_base64",
+                "sizes": "(max-width: 600px) 100vw, 600px",
+                "src": "/thumb/image002.jpg",
+                "srcSet": "some srcSet",
+                "srcSetWebp": "some srcSetWebp",
+              },
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "fluid": Object {
+                "aspectRatio": 1.5,
+                "base64": "string_of_base64",
+                "sizes": "(max-width: 600px) 100vw, 600px",
+                "src": "/thumb/image003.jpg",
+                "srcSet": "some srcSet",
+                "srcSetWebp": "some srcSetWebp",
+              },
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "fluid": Object {
+                "aspectRatio": 1.5,
+                "base64": "string_of_base64",
+                "sizes": "(max-width: 600px) 100vw, 600px",
+                "src": "/thumb/image004.jpg",
+                "srcSet": "some srcSet",
+                "srcSetWebp": "some srcSetWebp",
+              },
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "fluid": Object {
+                "aspectRatio": 1.5,
+                "base64": "string_of_base64",
+                "sizes": "(max-width: 600px) 100vw, 600px",
+                "src": "/thumb/image005.jpg",
+                "srcSet": "some srcSet",
+                "srcSetWebp": "some srcSetWebp",
+              },
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.div)>
+</React.Fragment>
+`;
+
 exports[`Gallery component that it renders with data in images & thumbs 1`] = `
 <React.Fragment>
   <ForwardRef(styled.div)>
@@ -480,5 +637,152 @@ exports[`Gallery component that it renders with data in thumbs 1`] = `
 exports[`Gallery component that it renders with empty props 1`] = `
 <React.Fragment>
   <ForwardRef(styled.div) />
+</React.Fragment>
+`;
+
+exports[`Gallery component that it renders with unified image prop 1`] = `
+<React.Fragment>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image001.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image002.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image003.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image004.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image005.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.div)>
 </React.Fragment>
 `;

--- a/gatsby-image-gallery/src/index.js
+++ b/gatsby-image-gallery/src/index.js
@@ -8,23 +8,46 @@ import Col from './column'
 import ImgWrapper from './img-wrapper'
 
 const Gallery = ({
-  images,
-  thumbs,
+  images = null,
+  thumbs = null,
+  fullImages = null,
   colWidth = 100 / 3,
   mdColWidth = 100 / 4,
   gutter = '0.25rem',
   imgClass = '',
 }) => {
+  let thumbsArray, imagesArray
+  if (thumbs === null && fullImages === null) {
+    // New style with all images in one prop
+    thumbsArray = images.map(({ node }) => node.childImageSharp.thumb)
+    imagesArray = images.map(({ node }) => node.childImageSharp.fluid.src)
+  } else {
+    // Compat with old props
+    thumbsArray = thumbs
+    if (fullImages === null && images !== null) {
+      console.warn(
+        `Using the images props with thumbs is deprecated and will not 
+        be supported in the next major version. If you need to pass 2 arrays 
+        separately, use the new prop "fullImages" instead which works exactly 
+        the same way as "images" used to. It's recommended to pass all data in 
+        the "images" prop instead.`
+      )
+      imagesArray = images
+    } else {
+      imagesArray = fullImages
+    }
+  }
+
   const [index, setIndex] = useState(0)
   const [isOpen, setIsOpen] = useState(false)
 
-  const prevIndex = index - (1 % images.length)
-  const nextIndex = (index + images.length + 1) % images.length
+  const prevIndex = index - (1 % imagesArray.length)
+  const nextIndex = (index + imagesArray.length + 1) % imagesArray.length
 
   return (
     <React.Fragment>
       <Row>
-        {thumbs.map((thumbnail, thumbIndex) => {
+        {thumbsArray.map((thumbnail, thumbIndex) => {
           return (
             <Col
               width={colWidth}
@@ -44,9 +67,9 @@ const Gallery = ({
       </Row>
       {isOpen && (
         <Lightbox
-          mainSrc={images[index]}
-          nextSrc={images[nextIndex]}
-          prevSrc={images[prevIndex]}
+          mainSrc={imagesArray[index]}
+          nextSrc={imagesArray[nextIndex]}
+          prevSrc={imagesArray[prevIndex]}
           onCloseRequest={() => setIsOpen(false)}
           onMovePrevRequest={() => setIndex(prevIndex)}
           onMoveNextRequest={() => setIndex(nextIndex)}
@@ -65,8 +88,9 @@ const Gallery = ({
 export default Gallery
 
 Gallery.propTypes = {
-  images: PropTypes.array.isRequired,
-  thumbs: PropTypes.array.isRequired,
+  images: PropTypes.array,
+  thumbs: PropTypes.array,
+  fullImages: PropTypes.array,
   colWidth: PropTypes.number,
   mdColWidth: PropTypes.number,
   gutter: PropTypes.string,

--- a/gatsby-image-gallery/src/index.test.js
+++ b/gatsby-image-gallery/src/index.test.js
@@ -11,6 +11,15 @@ const fluidShapeMock = (path) => ({
   base64: `string_of_base64`,
 })
 
+const unifiedImageNodeShapeMock = (path) => ({
+  node: {
+    childImageSharp: {
+      thumb: fluidShapeMock(`/thumb${path}`),
+      fluid: fluidShapeMock(path),
+    },
+  },
+})
+
 describe('Gallery component', () => {
   test('that it renders with empty props', () => {
     const renderer = new ShallowRenderer()
@@ -70,6 +79,46 @@ describe('Gallery component', () => {
           { fluid: fluidShapeMock('/thumb/image003.jpg') },
           { fluid: fluidShapeMock('/thumb/image004.jpg') },
           { fluid: fluidShapeMock('/thumb/image005.jpg') },
+        ]}
+      />
+    )
+    const result = renderer.getRenderOutput()
+    expect(result).toMatchSnapshot()
+  })
+
+  test('that it renders with data in fullImages & thumbs', () => {
+    const renderer = new ShallowRenderer()
+    renderer.render(
+      <Gallery
+        fullImages={[
+          '/images/image001.jpg',
+          '/images/image002.jpg',
+          '/images/image003.jpg',
+          '/images/image004.jpg',
+        ]}
+        thumbs={[
+          { fluid: fluidShapeMock('/thumb/image001.jpg') },
+          { fluid: fluidShapeMock('/thumb/image002.jpg') },
+          { fluid: fluidShapeMock('/thumb/image003.jpg') },
+          { fluid: fluidShapeMock('/thumb/image004.jpg') },
+          { fluid: fluidShapeMock('/thumb/image005.jpg') },
+        ]}
+      />
+    )
+    const result = renderer.getRenderOutput()
+    expect(result).toMatchSnapshot()
+  })
+
+  test('that it renders with unified image prop', () => {
+    const renderer = new ShallowRenderer()
+    renderer.render(
+      <Gallery
+        images={[
+          unifiedImageNodeShapeMock('/images/image001.jpg'),
+          unifiedImageNodeShapeMock('/images/image002.jpg'),
+          unifiedImageNodeShapeMock('/images/image003.jpg'),
+          unifiedImageNodeShapeMock('/images/image004.jpg'),
+          unifiedImageNodeShapeMock('/images/image005.jpg'),
         ]}
       />
     )


### PR DESCRIPTION
Update the `images` props to support passing thumbnails and full size images together.

The old behaviour of using `images` with `thumbs` is deprecated in favour of either

- `fullImages` with `thumbs`
OR
- Passing full w/ thumbs in single array of `images`