### PR TITLE
feat(component): Alt property added for thumbnails

### DIFF
--- a/gatsby-image-gallery/src/__snapshots__/index.test.js.snap
+++ b/gatsby-image-gallery/src/__snapshots__/index.test.js.snap
@@ -1,5 +1,446 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Gallery component Unified image prop that it renders image prop when alt property is used 1`] = `
+<React.Fragment>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="001"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image001.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="002"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image002.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="003"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image003.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="004"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image004.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="005"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image005.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.div)>
+</React.Fragment>
+`;
+
+exports[`Gallery component Unified image prop that it renders image prop when no alt property is used 1`] = `
+<React.Fragment>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image001.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image002.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image003.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image004.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image005.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.div)>
+</React.Fragment>
+`;
+
+exports[`Gallery component Unified image prop that it renders image prop when only in some cases the alt property is used 1`] = `
+<React.Fragment>
+  <ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="001"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image001.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="002"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image002.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image003.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt=""
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image004.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+    <ForwardRef(styled.div)
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <ForwardRef(styled.div)
+        margin="0.25rem"
+      >
+        <Image
+          Tag="div"
+          alt="005"
+          className=""
+          durationFadeIn={500}
+          fadeIn={true}
+          fluid={
+            Object {
+              "aspectRatio": 1.5,
+              "base64": "string_of_base64",
+              "sizes": "(max-width: 600px) 100vw, 600px",
+              "src": "/thumb/images/image005.jpg",
+              "srcSet": "some srcSet",
+              "srcSetWebp": "some srcSetWebp",
+            }
+          }
+          loading="lazy"
+        />
+      </ForwardRef(styled.div)>
+    </ForwardRef(styled.div)>
+  </ForwardRef(styled.div)>
+</React.Fragment>
+`;
+
 exports[`Gallery component that it renders with a custom column class 1`] = `
 <React.Fragment>
   <ForwardRef(styled.div)>
@@ -637,152 +1078,5 @@ exports[`Gallery component that it renders with data in thumbs 1`] = `
 exports[`Gallery component that it renders with empty props 1`] = `
 <React.Fragment>
   <ForwardRef(styled.div) />
-</React.Fragment>
-`;
-
-exports[`Gallery component that it renders with unified image prop 1`] = `
-<React.Fragment>
-  <ForwardRef(styled.div)>
-    <ForwardRef(styled.div)
-      md={25}
-      onClick={[Function]}
-      width={33.333333333333336}
-    >
-      <ForwardRef(styled.div)
-        margin="0.25rem"
-      >
-        <Image
-          Tag="div"
-          alt=""
-          className=""
-          durationFadeIn={500}
-          fadeIn={true}
-          fluid={
-            Object {
-              "aspectRatio": 1.5,
-              "base64": "string_of_base64",
-              "sizes": "(max-width: 600px) 100vw, 600px",
-              "src": "/thumb/images/image001.jpg",
-              "srcSet": "some srcSet",
-              "srcSetWebp": "some srcSetWebp",
-            }
-          }
-          loading="lazy"
-        />
-      </ForwardRef(styled.div)>
-    </ForwardRef(styled.div)>
-    <ForwardRef(styled.div)
-      md={25}
-      onClick={[Function]}
-      width={33.333333333333336}
-    >
-      <ForwardRef(styled.div)
-        margin="0.25rem"
-      >
-        <Image
-          Tag="div"
-          alt=""
-          className=""
-          durationFadeIn={500}
-          fadeIn={true}
-          fluid={
-            Object {
-              "aspectRatio": 1.5,
-              "base64": "string_of_base64",
-              "sizes": "(max-width: 600px) 100vw, 600px",
-              "src": "/thumb/images/image002.jpg",
-              "srcSet": "some srcSet",
-              "srcSetWebp": "some srcSetWebp",
-            }
-          }
-          loading="lazy"
-        />
-      </ForwardRef(styled.div)>
-    </ForwardRef(styled.div)>
-    <ForwardRef(styled.div)
-      md={25}
-      onClick={[Function]}
-      width={33.333333333333336}
-    >
-      <ForwardRef(styled.div)
-        margin="0.25rem"
-      >
-        <Image
-          Tag="div"
-          alt=""
-          className=""
-          durationFadeIn={500}
-          fadeIn={true}
-          fluid={
-            Object {
-              "aspectRatio": 1.5,
-              "base64": "string_of_base64",
-              "sizes": "(max-width: 600px) 100vw, 600px",
-              "src": "/thumb/images/image003.jpg",
-              "srcSet": "some srcSet",
-              "srcSetWebp": "some srcSetWebp",
-            }
-          }
-          loading="lazy"
-        />
-      </ForwardRef(styled.div)>
-    </ForwardRef(styled.div)>
-    <ForwardRef(styled.div)
-      md={25}
-      onClick={[Function]}
-      width={33.333333333333336}
-    >
-      <ForwardRef(styled.div)
-        margin="0.25rem"
-      >
-        <Image
-          Tag="div"
-          alt=""
-          className=""
-          durationFadeIn={500}
-          fadeIn={true}
-          fluid={
-            Object {
-              "aspectRatio": 1.5,
-              "base64": "string_of_base64",
-              "sizes": "(max-width: 600px) 100vw, 600px",
-              "src": "/thumb/images/image004.jpg",
-              "srcSet": "some srcSet",
-              "srcSetWebp": "some srcSetWebp",
-            }
-          }
-          loading="lazy"
-        />
-      </ForwardRef(styled.div)>
-    </ForwardRef(styled.div)>
-    <ForwardRef(styled.div)
-      md={25}
-      onClick={[Function]}
-      width={33.333333333333336}
-    >
-      <ForwardRef(styled.div)
-        margin="0.25rem"
-      >
-        <Image
-          Tag="div"
-          alt=""
-          className=""
-          durationFadeIn={500}
-          fadeIn={true}
-          fluid={
-            Object {
-              "aspectRatio": 1.5,
-              "base64": "string_of_base64",
-              "sizes": "(max-width: 600px) 100vw, 600px",
-              "src": "/thumb/images/image005.jpg",
-              "srcSet": "some srcSet",
-              "srcSetWebp": "some srcSetWebp",
-            }
-          }
-          loading="lazy"
-        />
-      </ForwardRef(styled.div)>
-    </ForwardRef(styled.div)>
-  </ForwardRef(styled.div)>
 </React.Fragment>
 `;

--- a/gatsby-image-gallery/src/index.js
+++ b/gatsby-image-gallery/src/index.js
@@ -18,11 +18,12 @@ const Gallery = ({
   gutter = '0.25rem',
   imgClass = '',
 }) => {
-  let thumbsArray, fullArray
+  let thumbsArray, fullArray, thumbAltArray
   if (thumbs === null && fullImages === null) {
     // New style with all images in one prop
     thumbsArray = images.map(({ thumb }) => thumb)
     fullArray = images.map(({ full }) => full.src)
+    thumbAltArray = images.map(({ thumbAlt }) => thumbAlt)
   } else {
     // Compat with old props
     thumbsArray = thumbs
@@ -64,7 +65,8 @@ const Gallery = ({
               }}
             >
               <ImgWrapper margin={gutter}>
-                <Img fluid={thumbnail} className={imgClass} />
+                <Img fluid={thumbnail} className={imgClass}
+                  alt={thumbAltArray ? thumbAltArray[thumbIndex] ? thumbAltArray[thumbIndex] : "" : ""} />
               </ImgWrapper>
             </Col>
           )
@@ -97,6 +99,7 @@ Gallery.propTypes = {
     PropTypes.shape({
       full: PropTypes.object,
       thumb: PropTypes.object,
+      thumbAlt: PropTypes.string
     })
   ),
   thumbs: PropTypes.array,

--- a/gatsby-image-gallery/src/index.js
+++ b/gatsby-image-gallery/src/index.js
@@ -65,8 +65,17 @@ const Gallery = ({
               }}
             >
               <ImgWrapper margin={gutter}>
-                <Img fluid={thumbnail} className={imgClass}
-                  alt={thumbAltArray ? thumbAltArray[thumbIndex] ? thumbAltArray[thumbIndex] : "" : ""} />
+                <Img
+                  fluid={thumbnail}
+                  className={imgClass}
+                  alt={
+                    thumbAltArray
+                      ? thumbAltArray[thumbIndex]
+                        ? thumbAltArray[thumbIndex]
+                        : ''
+                      : ''
+                  }
+                />
               </ImgWrapper>
             </Col>
           )
@@ -99,7 +108,7 @@ Gallery.propTypes = {
     PropTypes.shape({
       full: PropTypes.object,
       thumb: PropTypes.object,
-      thumbAlt: PropTypes.string
+      thumbAlt: PropTypes.string,
     })
   ),
   thumbs: PropTypes.array,

--- a/gatsby-image-gallery/src/index.test.js
+++ b/gatsby-image-gallery/src/index.test.js
@@ -11,9 +11,10 @@ const fluidShapeMock = (path) => ({
   base64: `string_of_base64`,
 })
 
-const unifiedImageShapeMock = (path) => ({
+const unifiedImageShapeMock = (path, alt) => ({
   thumb: fluidShapeMock(`/thumb${path}`),
   full: fluidShapeMock(path),
+  thumbAlt: alt,
 })
 
 describe('Gallery component', () => {
@@ -105,23 +106,6 @@ describe('Gallery component', () => {
     expect(result).toMatchSnapshot()
   })
 
-  test('that it renders with unified image prop', () => {
-    const renderer = new ShallowRenderer()
-    renderer.render(
-      <Gallery
-        images={[
-          unifiedImageShapeMock('/images/image001.jpg'),
-          unifiedImageShapeMock('/images/image002.jpg'),
-          unifiedImageShapeMock('/images/image003.jpg'),
-          unifiedImageShapeMock('/images/image004.jpg'),
-          unifiedImageShapeMock('/images/image005.jpg'),
-        ]}
-      />
-    )
-    const result = renderer.getRenderOutput()
-    expect(result).toMatchSnapshot()
-  })
-
   test('that it renders with a custom column class', () => {
     const renderer = new ShallowRenderer()
     renderer.render(
@@ -144,5 +128,58 @@ describe('Gallery component', () => {
     )
     const result = renderer.getRenderOutput()
     expect(result).toMatchSnapshot()
+  })
+
+  describe('Unified image prop', ()=>{
+    test('that it renders image prop when no alt property is used', () => {
+      const renderer = new ShallowRenderer()
+      renderer.render(
+        <Gallery
+          images={[
+            unifiedImageShapeMock('/images/image001.jpg'),
+            unifiedImageShapeMock('/images/image002.jpg'),
+            unifiedImageShapeMock('/images/image003.jpg'),
+            unifiedImageShapeMock('/images/image004.jpg'),
+            unifiedImageShapeMock('/images/image005.jpg'),
+          ]}
+        />
+      )
+      const result = renderer.getRenderOutput()
+      expect(result).toMatchSnapshot()
+    })
+  
+    test('that it renders image prop when alt property is used', () => {
+      const renderer = new ShallowRenderer()
+      renderer.render(
+        <Gallery
+          images={[
+            unifiedImageShapeMock('/images/image001.jpg', '001'),
+            unifiedImageShapeMock('/images/image002.jpg', '002'),
+            unifiedImageShapeMock('/images/image003.jpg', '003'),
+            unifiedImageShapeMock('/images/image004.jpg', '004'),
+            unifiedImageShapeMock('/images/image005.jpg', '005'),
+          ]}
+        />
+      )
+      const result = renderer.getRenderOutput()
+      expect(result).toMatchSnapshot()
+    })
+
+    test('that it renders image prop when only in some cases the alt property is used', () => {
+      const renderer = new ShallowRenderer()
+      renderer.render(
+        <Gallery
+          images={[
+            unifiedImageShapeMock('/images/image001.jpg', '001'),
+            unifiedImageShapeMock('/images/image002.jpg', '002'),
+            unifiedImageShapeMock('/images/image003.jpg'),
+            unifiedImageShapeMock('/images/image004.jpg'),
+            unifiedImageShapeMock('/images/image005.jpg', '005'),
+          ]}
+        />
+      )
+      const result = renderer.getRenderOutput()
+      expect(result).toMatchSnapshot()
+    })
   })
 })

--- a/gatsby-image-gallery/src/index.test.js
+++ b/gatsby-image-gallery/src/index.test.js
@@ -130,7 +130,7 @@ describe('Gallery component', () => {
     expect(result).toMatchSnapshot()
   })
 
-  describe('Unified image prop', ()=>{
+  describe('Unified image prop', () => {
     test('that it renders image prop when no alt property is used', () => {
       const renderer = new ShallowRenderer()
       renderer.render(
@@ -147,7 +147,7 @@ describe('Gallery component', () => {
       const result = renderer.getRenderOutput()
       expect(result).toMatchSnapshot()
     })
-  
+
     test('that it renders image prop when alt property is used', () => {
       const renderer = new ShallowRenderer()
       renderer.render(


### PR DESCRIPTION
As discussed in #492 I added the possibility to pass `alt` properties for the thumbnails. It is optional, if there is no `alt` property for an image it defaults back to an empty `alt`, as it was before my modification. I also updated the tests with the new cases (I added a separate `describe` for the unified image property, this is why there are so many changes in the snapshot). I tested it from the example app also, it worked as expected.

The PR is ready for review. 