### PR TITLE
[Fix] change onClose call order (#659)

### DIFF
--- a/gatsby-image-gallery/src/index.js
+++ b/gatsby-image-gallery/src/index.js
@@ -36,8 +36,8 @@ const Gallery = ({
   const nextIndex = (index + fullArray.length + 1) % fullArray.length
 
   const onCloseLightbox = () => {
-    setIsOpen(false)
     onClose()
+    setIsOpen(false)
   }
 
   return (


### PR DESCRIPTION
# WHAT
This PR only changes the order the `onClose` is called.

PS: sorry I've only noticed that I've called the method on the wrong order after testing on my app (I wasn't able to test it before the release).
PS.2: thanks for accepting my contribution