### PR TITLE
feat: add prop for row margin and center columns

### DIFF
--- a/gatsby-image-gallery/src/column.tsx
+++ b/gatsby-image-gallery/src/column.tsx
@@ -8,6 +8,9 @@ interface ColProps {
 const Col = styled.div<ColProps>`
   flex-grow: 0;
   flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  display: flex;
   ${(props) => {
     return css`
       flex-basis: ${props.width}%;

--- a/gatsby-image-gallery/src/index.tsx
+++ b/gatsby-image-gallery/src/index.tsx
@@ -21,6 +21,7 @@ interface GalleryProps {
   images: ImageProp[]
   colWidth?: number
   mdColWidth?: number
+  rowMargin?: number
   gutter?: string
   imgClass?: string
   lightboxOptions?: object
@@ -36,6 +37,7 @@ const Gallery: FC<GalleryProps> = ({
   colWidth = 100 / 3,
   mdColWidth = 100 / 4,
   gutter = '0.25rem',
+  rowMargin = -15,
   imgClass = '',
   lightboxOptions = {},
   onClose = () => {},
@@ -58,7 +60,7 @@ const Gallery: FC<GalleryProps> = ({
 
   return (
     <React.Fragment>
-      <Row>
+      <Row margin={rowMargin}>
         {images.map((img, imgIndex) => {
           const thumbImage = getImage(img.thumb)
           if (!thumbImage) {

--- a/gatsby-image-gallery/src/row.tsx
+++ b/gatsby-image-gallery/src/row.tsx
@@ -1,9 +1,17 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-const Row = styled.div`
+interface RowProps {
+  margin: number
+}
+
+const Row = styled.div<RowProps>`
   display: flex;
   flex-wrap: wrap;
-  margin-right: -15px;
-  margin-left: -15px;
+  ${(props) => {
+    return css`
+      margin-right: ${props.margin || -15}px;
+      margin-left: ${props.margin || -15}px;
+    `
+  }}
 `
 export default Row

--- a/gatsby-image-gallery/src/row.tsx
+++ b/gatsby-image-gallery/src/row.tsx
@@ -9,8 +9,8 @@ const Row = styled.div<RowProps>`
   flex-wrap: wrap;
   ${(props) => {
     return css`
-      margin-right: ${props.margin || -15}px;
-      margin-left: ${props.margin || -15}px;
+      margin-right: ${props.margin}px;
+      margin-left: ${props.margin}px;
     `
   }}
 `

--- a/gatsby-image-gallery/test/__snapshots__/index.test.tsx.snap
+++ b/gatsby-image-gallery/test/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Gallery component Unified image prop that it renders image prop when alt property is used 1`] = `
 <React.Fragment>
-  <styled.div>
+  <styled.div
+    margin={-15}
+  >
     <styled.div
       md={25}
       onClick={[Function]}
@@ -184,7 +186,9 @@ exports[`Gallery component Unified image prop that it renders image prop when al
 
 exports[`Gallery component Unified image prop that it renders image prop when no alt property is used 1`] = `
 <React.Fragment>
-  <styled.div>
+  <styled.div
+    margin={-15}
+  >
     <styled.div
       md={25}
       onClick={[Function]}
@@ -366,7 +370,9 @@ exports[`Gallery component Unified image prop that it renders image prop when no
 
 exports[`Gallery component Unified image prop that it renders image prop when only in some cases the alt property is used 1`] = `
 <React.Fragment>
-  <styled.div>
+  <styled.div
+    margin={-15}
+  >
     <styled.div
       md={25}
       onClick={[Function]}
@@ -548,7 +554,9 @@ exports[`Gallery component Unified image prop that it renders image prop when on
 
 exports[`Gallery component lightboxOptions props that the Lightbox options are accepted 1`] = `
 <React.Fragment>
-  <styled.div>
+  <styled.div
+    margin={-15}
+  >
     <styled.div
       md={25}
       onClick={[Function]}
@@ -660,7 +668,123 @@ exports[`Gallery component lightboxOptions props that the Lightbox options are a
 
 exports[`Gallery component onClose prop onClose prop is accepted 1`] = `
 <React.Fragment>
-  <styled.div>
+  <styled.div
+    margin={-15}
+  >
+    <styled.div
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <styled.div
+        margin="0.25rem"
+      >
+        <A
+          alt=""
+          className=""
+          image={
+            Object {
+              "backgroundColor": "red",
+              "height": 100,
+              "images": Object {
+                "alt": "/thumb/images/image001.jpg",
+                "fallback": Object {
+                  "src": "/thumb/images/image001.jpg",
+                },
+                "sources": Array [
+                  Object {
+                    "media": "/thumb/images/image001.jpg",
+                    "srcSet": "/thumb/images/image001.jpg",
+                    "type": "JPG",
+                  },
+                ],
+              },
+              "layout": "constrained",
+              "width": 100,
+            }
+          }
+        />
+      </styled.div>
+    </styled.div>
+    <styled.div
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <styled.div
+        margin="0.25rem"
+      >
+        <A
+          alt=""
+          className=""
+          image={
+            Object {
+              "backgroundColor": "red",
+              "height": 100,
+              "images": Object {
+                "alt": "/thumb/images/image002.jpg",
+                "fallback": Object {
+                  "src": "/thumb/images/image002.jpg",
+                },
+                "sources": Array [
+                  Object {
+                    "media": "/thumb/images/image002.jpg",
+                    "srcSet": "/thumb/images/image002.jpg",
+                    "type": "JPG",
+                  },
+                ],
+              },
+              "layout": "constrained",
+              "width": 100,
+            }
+          }
+        />
+      </styled.div>
+    </styled.div>
+    <styled.div
+      md={25}
+      onClick={[Function]}
+      width={33.333333333333336}
+    >
+      <styled.div
+        margin="0.25rem"
+      >
+        <A
+          alt=""
+          className=""
+          image={
+            Object {
+              "backgroundColor": "red",
+              "height": 100,
+              "images": Object {
+                "alt": "/thumb/images/image003.jpg",
+                "fallback": Object {
+                  "src": "/thumb/images/image003.jpg",
+                },
+                "sources": Array [
+                  Object {
+                    "media": "/thumb/images/image003.jpg",
+                    "srcSet": "/thumb/images/image003.jpg",
+                    "type": "JPG",
+                  },
+                ],
+              },
+              "layout": "constrained",
+              "width": 100,
+            }
+          }
+        />
+      </styled.div>
+    </styled.div>
+  </styled.div>
+</React.Fragment>
+`;
+
+exports[`Gallery component rowMargin prop that the rowMargin prop is accepted 1`] = `
+<React.Fragment>
+  <styled.div
+    margin={0}
+  >
     <styled.div
       md={25}
       onClick={[Function]}
@@ -772,6 +896,8 @@ exports[`Gallery component onClose prop onClose prop is accepted 1`] = `
 
 exports[`Gallery component that it renders with empty props 1`] = `
 <React.Fragment>
-  <styled.div />
+  <styled.div
+    margin={-15}
+  />
 </React.Fragment>
 `;

--- a/gatsby-image-gallery/test/index.test.tsx
+++ b/gatsby-image-gallery/test/index.test.tsx
@@ -121,6 +121,27 @@ describe('Gallery component', () => {
     })
   })
 
+  describe('rowMargin prop', () => {
+    const rowMargin = 0
+
+    test('that the rowMargin prop is accepted', () => {
+      const renderer = createRenderer()
+      renderer.render(
+        <Gallery
+          images={[
+            unifiedImageShapeMock('/images/image001.jpg'),
+            unifiedImageShapeMock('/images/image002.jpg'),
+            unifiedImageShapeMock('/images/image003.jpg'),
+          ]}
+          rowMargin={rowMargin}
+        />
+      )
+
+      const result = renderer.getRenderOutput()
+      expect(result).toMatchSnapshot()
+    })
+  })
+
   describe('onClose prop', () => {
     const onClose = () => {
       console.log('test onClose')


### PR DESCRIPTION
I was having style issues where the gallery overhung the left side of my container. This PR centers the columns and adds a rowMargin prop that defaults to the existing -15px.