### PR TITLE
fix(deps): update react-image-lightbox to 5.1.4

### DIFF
--- a/gatsby-image-gallery/package.json
+++ b/gatsby-image-gallery/package.json
@@ -32,7 +32,7 @@
     "styled-components": ">= 5.0"
   },
   "dependencies": {
-    "react-image-lightbox": "^5.1.1",
+    "react-image-lightbox": "^5.1.4",
     "styled-components": "^5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The peer dependency has been updated to allow React 17.

Fix #629