### PR TITLE
fix: allow `ReactNode` type for `title` and `caption`

### DIFF
--- a/gatsby-image-gallery/src/index.tsx
+++ b/gatsby-image-gallery/src/index.tsx
@@ -12,8 +12,8 @@ interface ImageProp {
   full: IGatsbyImageData
   thumb: IGatsbyImageData
   thumbAlt?: string
-  title?: string
-  caption?: string
+  title?: React.ReactNode
+  caption?: React.ReactNode
 }
 
 interface GalleryProps {


### PR DESCRIPTION
`string` is already part of the `ReactNode` union type, so this change works