### PR TITLE
docs: update link for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gatsby-image-gallery
 
 <p align="center">
-  <a href="https://github.com/browniebroke/gatsby-image-gallery/actions?query=workflow%3ACI">
+  <a href="https://github.com/browniebroke/gatsby-image-gallery/actions/workflows/ci.yml?query=branch%3Amain">
     <img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/browniebroke/gatsby-image-gallery/ci.yml?branch=main&label=CI&logo=github&logoColor=white&style=flat-square">
   </a>
   <a href="https://www.npmjs.com/package/@browniebroke/gatsby-image-gallery">


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos